### PR TITLE
update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,86 @@
 FROM python:3.7.4
-# FROM python:3.6.9
 
-LABEL maintainer "Amine Hadj-Youcef  <hadjyoucef.amine@gmail.com>"
-# If you have any comment : LinkedIn - https://www.linkedin.com/in/aminehy/
+
+# --------------- Install python packages using `pip` ---------------
+
+
+
+# https://github.com/joyzoursky/docker-python-chromedriver/blob/master/py3/py3.6-xvfb-selenium/Dockerfile
+RUN apt-get update 
+# install selenium
+RUN apt-get install -y python3-software-properties
+RUN apt-get install -y software-properties-common
+RUN apt-get -y install apt-transport-https ca-certificates
+RUN apt-get -y install apt-transport-https curl
+RUN apt-get -y install wget curl
+RUN apt-get install -y firefox-esr
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        bzip2 \
+        libfontconfig \
+    && apt-get clean
+
+RUN apt-get install --fix-missing
+RUN pip install nltk
+RUN pip install selenium==3.8.0
+RUN pip install --upgrade pip
+# set dbus env to avoid hanging
+ENV DISPLAY=:99
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+#RUN pip install --upgrade selenium
+
+##
+# Programatic Firefox driver that can bind with selenium/gecko.
+##
+RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz
+RUN tar -xvzf geckodriver-v0.23.0-linux64.tar.gz
+RUN sh -c 'tar -x geckodriver -zf geckodriver-v0.23.0-linux64.tar.gz -O > /usr/bin/geckodriver'
+RUN chmod +x /usr/bin/geckodriver
+RUN rm geckodriver-v0.23.0-linux64.tar.gz
+
+RUN cp geckodriver /usr/local/bin/
+ENV PATH /usr/bin/geckodriver:$PATH
+RUN pip install pyvirtualdisplay
+# A lot of academic text is still in PDF, so better get some tools to deal with that.
+#RUN sudo /opt/conda/bin/pip install git+https://github.com/pdfminer/pdfminer.six.git
+
+ENV MOZ_HEADLESS = 1
+RUN python - c "from selenium import webdriver;\
+from selenium.webdriver.firefox.options import Options; \
+options = Options(); \
+options.headless = True; \
+driver = webdriver.Firefox(options=options) ;\
+driver.get('http://google.com/') ;\
+print('Headless Firefox Initialized') ;\
+driver.quit();"
+
+RUN apt-get update
+ENV PATH="/root/miniconda3/bin:${PATH}"
+ARG PATH="/root/miniconda3/bin:${PATH}"
+RUN apt-get update
+
+RUN apt-get install -y wget && rm -rf /var/lib/apt/lists/*
+
+RUN wget \
+    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    && mkdir /root/.conda \
+    && bash Miniconda3-latest-Linux-x86_64.sh -b \
+    && rm -f Miniconda3-latest-Linux-x86_64.sh 
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+RUN conda --version
+RUN conda update --yes conda
+RUN conda install --yes gcc_linux-64
+
+ADD . .
+ADD requirements.txt ./
 
 # Copy local code to the container image.
 ENV APP_HOME /app
 
 WORKDIR $APP_HOME
 COPY . ./
-
-# --------------- Install python packages using `pip` ---------------
 
 RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt \
 	&& rm -rf requirements.txt
@@ -24,7 +94,7 @@ RUN bash -c 'echo -e "\
 	" > /root/.streamlit/config.toml'
 
 EXPOSE 8501
-EXPOSE 8080
+
 
 # --------------- Export envirennement variable ---------------
 ENV LC_ALL=C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.0
+FROM python:3.7.4
 # FROM python:3.6.9
 
 LABEL maintainer "Amine Hadj-Youcef  <hadjyoucef.amine@gmail.com>"
@@ -14,7 +14,7 @@ COPY . ./
 
 RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt \
 	&& rm -rf requirements.txt
-
+RUN pip install --upgrade streamlit
 # --------------- Configure Streamlit ---------------
 RUN mkdir -p /root/.streamlit
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ docker run -ti --rm aminehy/docker-streamlit-app:latest
 
 - To access the docker container in the bash mode
 ```
-docker run -ti --rm aminehy/deploy_streamlit_app:latest bash
+docker run -ti --rm -p 8080 aminehy/deploy_streamlit_app:latest bash
 ```
+Two addresses will come up, only the top URL is functional.
 
 # Build docker image
 You can build this docker image from a dockerfile using this command


### PR DESCRIPTION
The older version of python/streamlit was causing
```
ImportError: cannot import name 'Deque'
```
Also with running the docker command `docker run -it` without `-p` also specified the URLS would just hang.